### PR TITLE
make functions generic over `Float` type using `num-traits`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
     "Mohamed Hayibor <mohamedhayibor@gmail.com>",
     "Mathis Wellmann <wellmannmathis@gmail.com",
 ]
+edition = "2024"
 
 publish = true
 description = "This crate provides utilities to round your floats with precision from 1 to 10."
@@ -15,3 +16,5 @@ repository = "https://github.com/mohamedhayibor/round"
 license = "GPL-2.0"
 keywords = ["round", "rounding", "precision", "decimals", "floats"]
 
+[dependencies]
+num-traits = "0.2.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,68 +2,70 @@
 // GNU licensed, license file can be found at the root of the repository
 // Mohamed Hayibor - Copyright 2016
 
-pub fn round(number: f64, rounding: i32) -> f64 {
-  let scale: f64 = 10_f64.powi(rounding);
-  (number * scale).round() / scale
+use num_traits::Float;
+
+pub fn round<T: Float>(number: T, rounding: i32) -> T {
+    let scale = T::from(10).expect("Can create").powi(rounding);
+    (number * scale).round() / scale
 }
 
 // implementing round_up and round_down with same design pattern
-pub fn round_up(number: f64, rounding: i32) -> f64 {
-  let scale: f64 = 10_f64.powi(rounding);
-  (number * scale).ceil() / scale
+pub fn round_up<T: Float>(number: T, rounding: i32) -> T {
+    let scale = T::from(10).expect("Can create").powi(rounding);
+    (number * scale).ceil() / scale
 }
 
-pub fn round_down(number: f64, rounding: i32) -> f64 {
-  let scale: f64 = 10_f64.powi(rounding);
-  (number * scale).floor() / scale
+pub fn round_down<T: Float>(number: T, rounding: i32) -> T {
+    let scale = T::from(10).expect("Can create").powi(rounding);
+    (number * scale).floor() / scale
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  
-  #[test]
-  fn test_round() {
-    let pi: f64 = std::f64::consts::PI;
+    use super::*;
 
-    assert_eq!(round(pi, 0), 3.0);
-    assert_eq!(round(pi, 1), 3.1);
-    assert_eq!(round(pi, 2), 3.14);
-    assert_eq!(round(pi, 3), 3.142);
-    assert_eq!(round(pi, 4), 3.1416);
-    assert_eq!(round(pi, 5), 3.14159);
-    assert_eq!(round(pi, 6), 3.141593);
-    assert_eq!(round(pi, 7), 3.1415927);
-    assert_eq!(round(pi, 8), 3.14159265);
-  }
+    #[test]
+    fn test_round() {
+        let pi: f64 = std::f64::consts::PI;
 
-  #[test]
-  fn test_round_down() {
-    let pi: f64 = std::f64::consts::PI;
+        assert_eq!(round(pi, 0), 3.0);
+        assert_eq!(round(pi, 1), 3.1);
+        assert_eq!(round(pi, 2), 3.14);
+        assert_eq!(round(pi, 3), 3.142);
+        assert_eq!(round(pi, 4), 3.1416);
+        assert_eq!(round(pi, 5), 3.14159);
+        assert_eq!(round(pi, 6), 3.141593);
+        assert_eq!(round(pi, 7), 3.1415927);
+        assert_eq!(round(pi, 8), 3.14159265);
+    }
 
-    assert_eq!(round_down(pi, 0), 3.0);
-    assert_eq!(round_down(pi, 1), 3.1);
-    assert_eq!(round_down(pi, 2), 3.14);
-    assert_eq!(round_down(pi, 3), 3.141);
-    assert_eq!(round_down(pi, 4), 3.1415);
-    assert_eq!(round_down(pi, 5), 3.14159);
-    assert_eq!(round_down(pi, 6), 3.141592);
-    assert_eq!(round_down(pi, 7), 3.1415926);
-    assert_eq!(round_down(pi, 8), 3.14159265);
-  }
+    #[test]
+    fn test_round_down() {
+        let pi: f64 = std::f64::consts::PI;
 
-  #[test]
-  fn test_round_up() {
-    let pi: f64 = std::f64::consts::PI;
-    
-    assert_eq!(round_up(pi, 0), 4.0);
-    assert_eq!(round_up(pi, 1), 3.2);
-    assert_eq!(round_up(pi, 2), 3.15);
-    assert_eq!(round_up(pi, 3), 3.142);
-    assert_eq!(round_up(pi, 4), 3.1416);
-    assert_eq!(round_up(pi, 5), 3.14160);
-    assert_eq!(round_up(pi, 6), 3.141593);
-    assert_eq!(round_up(pi, 7), 3.1415927);
-    assert_eq!(round_up(pi, 8), 3.14159266);
-  }
+        assert_eq!(round_down(pi, 0), 3.0);
+        assert_eq!(round_down(pi, 1), 3.1);
+        assert_eq!(round_down(pi, 2), 3.14);
+        assert_eq!(round_down(pi, 3), 3.141);
+        assert_eq!(round_down(pi, 4), 3.1415);
+        assert_eq!(round_down(pi, 5), 3.14159);
+        assert_eq!(round_down(pi, 6), 3.141592);
+        assert_eq!(round_down(pi, 7), 3.1415926);
+        assert_eq!(round_down(pi, 8), 3.14159265);
+    }
+
+    #[test]
+    fn test_round_up() {
+        let pi: f64 = std::f64::consts::PI;
+
+        assert_eq!(round_up(pi, 0), 4.0);
+        assert_eq!(round_up(pi, 1), 3.2);
+        assert_eq!(round_up(pi, 2), 3.15);
+        assert_eq!(round_up(pi, 3), 3.142);
+        assert_eq!(round_up(pi, 4), 3.1416);
+        assert_eq!(round_up(pi, 5), 3.14160);
+        assert_eq!(round_up(pi, 6), 3.141593);
+        assert_eq!(round_up(pi, 7), 3.1415927);
+        assert_eq!(round_up(pi, 8), 3.14159266);
+    }
 }


### PR DESCRIPTION
This PR enables any `Float` type like f32, f64 to use these functions, which is more flexible compared to having to use `f64`.
Also formatted with `cargo fmt`.
Closes #4 